### PR TITLE
begin refactoring of API/resource discovery

### DIFF
--- a/cmd/grm-generate/command/aws.go
+++ b/cmd/grm-generate/command/aws.go
@@ -59,6 +59,9 @@ func discoverAWS(
 		discover.WithCachePath(sdkCachePath),
 		discover.WithServices(svcAlias),
 	)
-	_, err = disco.DiscoverResources(ctx)
+	resources, err := disco.DiscoverResources(ctx)
+	for _, r := range resources {
+		log.Debug("found resource", "resource", r.Kind.PluralName)
+	}
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/anydotcloud/grm v0.0.0-20230128222307-3e6973e34137
 	github.com/aws/aws-sdk-go v1.44.189
+	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/samber/lo v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/dlclark/regexp2 v1.8.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnm
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
+github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
+github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,8 +11,38 @@
 
 package config
 
+import "strings"
+
 // Config represents instructions to grm-generate on how to inspect a cloud
 // service API model, how to generate the consistent grm model for that API and
 // how to generate a resource manager that can manage resources in that API.
 type Config struct {
+	// Cloud specifies the cloud service that publishes this resource.
+	Cloud string `json:"cloud"`
+	// Resources contains generator instructions for individual CRDs within an
+	// API
+	Resources map[string]*ResourceConfig `json:"resources"`
+}
+
+// GetResourceConfigs returns the map, keyed by resource name, of
+// ResourceConfigs, or an empty map if the config is nil
+func (c *Config) GetResourceConfigs() map[string]*ResourceConfig {
+	if c == nil {
+		return map[string]*ResourceConfig{}
+	}
+	return c.Resources
+}
+
+// GetResourceConfig returns a ResourceConfig matching the supplied resource
+// name, using case-insensitive matching.
+func (c *Config) GetResourceConfig(search string) *ResourceConfig {
+	if c == nil {
+		return nil
+	}
+	for name, rc := range c.Resources {
+		if strings.EqualFold(name, search) {
+			return rc
+		}
+	}
+	return nil
 }

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -13,4 +13,33 @@ package config
 
 // ResourceConfig represents instructions to grm-generate on how to deal with a
 // particular resource.
-type ResourceConfig struct{}
+type ResourceConfig struct {
+	// AWS returns the AWS-specific resource configuration
+	AWS *AWSResourceConfig `json:"aws,omitempty"`
+}
+
+// ForAWS returns the AWS-specific resource configuration
+func (c *ResourceConfig) ForAWS() *AWSResourceConfig {
+	if c != nil && c.AWS != nil {
+		return c.AWS
+	}
+	return nil
+}
+
+// AWSResourceConfig contains AWS-specific configuration options for this
+// resource
+type AWSResourceConfig struct {
+	// Operations contains a map containing overrides for this resource's
+	// operations
+	Operations []*AWSResourceOperationConfig `json:"operations"`
+}
+
+// AWSResourceOperationConfig instructs the generator which AWS SDK Operation
+// to use for which type of operation for this resource.
+type AWSResourceOperationConfig struct {
+	// Type contains the stringified OpType, e.g. "create" or "READ_ONE"
+	Type string `json:"type"`
+	// ID contains the ID/name of the AWS SDK Operation that will serve as the
+	// OpType for this resource.
+	ID string `json:"id"`
+}

--- a/pkg/discover/aws/op.go
+++ b/pkg/discover/aws/op.go
@@ -1,0 +1,254 @@
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+	"github.com/gertd/go-pluralize"
+
+	"github.com/anydotcloud/grm-generate/pkg/config"
+	"github.com/anydotcloud/grm-generate/pkg/log"
+)
+
+type OpType int
+
+const (
+	OpTypeUnknown OpType = iota
+	OpTypeCreate
+	OpTypeCreateBatch
+	OpTypeDelete
+	OpTypeReplace
+	OpTypeUpdate
+	OpTypeAddChild
+	OpTypeAddChildren
+	OpTypeRemoveChild
+	OpTypeRemoveChildren
+	OpTypeGet
+	OpTypeList
+	OpTypeGetAttributes
+	OpTypeSetAttributes
+)
+
+type resourceOperationMap map[string]map[OpType]*awssdkmodel.Operation
+
+// GetOperationsForResource returns a map, keyed by OpType, for a supplied
+// resource. Resource name matching is case-insensitive.
+func (m resourceOperationMap) GetOperationsForResource(
+	resName string,
+) *map[OpType]*awssdkmodel.Operation {
+	for name, opMap := range m {
+		if strings.EqualFold(name, resName) {
+			return &opMap
+		}
+	}
+	return nil
+}
+
+// getResourceOperationMap returns a map, keyed by the resource name, of maps,
+// keyed by OpType, of aws-sdk-go private/model/api.Operation struct pointers
+// that describe that Operation for that resource.
+func getResourceOperationMap(
+	ctx context.Context,
+	api *awssdkmodel.API,
+	cfg *config.Config,
+) resourceOperationMap {
+	l := log.FromContext(ctx)
+	// create an index of Operations by resource name and operation type
+	res := resourceOperationMap{}
+	for opID, op := range api.Operations {
+		opType, resName := getOpTypeAndResourceNameFromOpID(opID, cfg)
+		resOps := res.GetOperationsForResource(resName)
+		if resOps == nil {
+			resOps = &map[OpType]*awssdkmodel.Operation{}
+		}
+		(*resOps)[opType] = op
+		res[resName] = *resOps
+	}
+
+	// We need to do a second pass over the operation overrides because some
+	// APIs have multiple operations of a particular OpType and we need to
+	// always be sure that the overridden operation is the one that we use
+	// during inference.
+	//
+	// An example of this is the Kinesis API which has two OpTypeGet
+	// Operations: DescribeStream and DescribeStreamSummary. We want the latter
+	// only and list that in our `operations:` configuration value.
+	for resName, rc := range cfg.GetResourceConfigs() {
+		arc := rc.ForAWS()
+		if arc == nil {
+			continue
+		}
+		resOps := res.GetOperationsForResource(resName)
+		if resOps == nil {
+			resOps = &map[OpType]*awssdkmodel.Operation{}
+		}
+		for x, aroc := range arc.Operations {
+			opID := aroc.ID
+			opType := getOpTypeFromString(aroc.Type)
+			if opType == OpTypeUnknown {
+				msg := fmt.Sprintf(
+					"operation type %s in config 'resources[%s].aws.operations[%d]:' "+
+						"is unknown",
+					aroc.Type, resName, x,
+				)
+				panic(msg)
+			}
+			op, found := api.Operations[opID]
+			if !found {
+				msg := fmt.Sprintf(
+					"operation %s in config 'resources[%s].aws.operations:' "+
+						"does not exist in API model.",
+					opID, resName,
+				)
+				panic(msg)
+			}
+			(*resOps)[opType] = op
+		}
+	}
+	l.Debug("res op map", "map", res)
+	return res
+}
+
+// getOpTypeAndResourceNameFromOpID guesses the resource name and type of
+// operation from the OperationID
+func getOpTypeAndResourceNameFromOpID(
+	opID string,
+	cfg *config.Config,
+) (OpType, string) {
+	pluralize := pluralize.NewClient()
+	if strings.HasPrefix(opID, "CreateOrUpdate") {
+		return OpTypeReplace, strings.TrimPrefix(opID, "CreateOrUpdate")
+	} else if strings.HasPrefix(opID, "BatchCreate") {
+		resName := strings.TrimPrefix(opID, "BatchCreate")
+		if pluralize.IsPlural(resName) {
+			// Do not singularize "pluralized singular" resources
+			// like EC2's DhcpOptions, if defined in generator config's list of
+			// resources.
+			rc := cfg.GetResourceConfig(resName)
+			if rc != nil {
+				return OpTypeCreateBatch, resName
+			}
+			return OpTypeCreateBatch, pluralize.Singular(resName)
+		}
+		return OpTypeCreateBatch, resName
+	} else if strings.HasPrefix(opID, "CreateBatch") {
+		resName := strings.TrimPrefix(opID, "CreateBatch")
+		if pluralize.IsPlural(resName) {
+			rc := cfg.GetResourceConfig(resName)
+			if rc != nil {
+				return OpTypeCreateBatch, resName
+			}
+			return OpTypeCreateBatch, pluralize.Singular(resName)
+		}
+		return OpTypeCreateBatch, resName
+	} else if strings.HasPrefix(opID, "Create") {
+		resName := strings.TrimPrefix(opID, "Create")
+		if pluralize.IsPlural(resName) {
+			// If resName exists in the generator configuration's list of
+			// resources, then just return OpTypeCreate and the resource name.
+			// This handles "pluralized singular" resource names like EC2's
+			// DhcpOptions.
+			rc := cfg.GetResourceConfig(resName)
+			if rc != nil {
+				return OpTypeCreate, resName
+			}
+			return OpTypeCreateBatch, pluralize.Singular(resName)
+		}
+		return OpTypeCreate, resName
+	} else if strings.HasPrefix(opID, "Modify") {
+		return OpTypeUpdate, strings.TrimPrefix(opID, "Modify")
+	} else if strings.HasPrefix(opID, "Update") {
+		return OpTypeUpdate, strings.TrimPrefix(opID, "Update")
+	} else if strings.HasPrefix(opID, "Delete") {
+		return OpTypeDelete, strings.TrimPrefix(opID, "Delete")
+	} else if strings.HasPrefix(opID, "Describe") {
+		resName := strings.TrimPrefix(opID, "Describe")
+		if pluralize.IsPlural(resName) {
+			rc := cfg.GetResourceConfig(resName)
+			if rc != nil {
+				return OpTypeList, resName
+			}
+			return OpTypeList, pluralize.Singular(resName)
+		}
+		return OpTypeGet, resName
+	} else if strings.HasPrefix(opID, "Get") {
+		if strings.HasSuffix(opID, "Attributes") {
+			resName := strings.TrimPrefix(opID, "Get")
+			resName = strings.TrimSuffix(resName, "Attributes")
+			return OpTypeGetAttributes, resName
+		}
+		resName := strings.TrimPrefix(opID, "Get")
+		if pluralize.IsPlural(resName) {
+			rc := cfg.GetResourceConfig(resName)
+			if rc != nil {
+				return OpTypeGet, resName
+			}
+			return OpTypeList, pluralize.Singular(resName)
+		}
+		return OpTypeGet, resName
+	} else if strings.HasPrefix(opID, "List") {
+		resName := strings.TrimPrefix(opID, "List")
+		if pluralize.IsPlural(resName) {
+			rc := cfg.GetResourceConfig(resName)
+			if rc != nil {
+				return OpTypeList, resName
+			}
+			return OpTypeList, pluralize.Singular(resName)
+		}
+		return OpTypeList, resName
+	} else if strings.HasPrefix(opID, "Set") {
+		if strings.HasSuffix(opID, "Attributes") {
+			resName := strings.TrimPrefix(opID, "Set")
+			resName = strings.TrimSuffix(resName, "Attributes")
+			return OpTypeSetAttributes, resName
+		}
+	}
+	return OpTypeUnknown, opID
+}
+
+// getOpTypeFromString translates a string literal into the associated OpType
+func getOpTypeFromString(s string) OpType {
+	switch strings.ToLower(s) {
+	case "create":
+		return OpTypeCreate
+	case "createbatch":
+		return OpTypeCreateBatch
+	case "delete":
+		return OpTypeDelete
+	case "replace":
+		return OpTypeReplace
+	case "update":
+		return OpTypeUpdate
+	case "addchild":
+		return OpTypeAddChild
+	case "addchildren":
+		return OpTypeAddChildren
+	case "removechild":
+		return OpTypeRemoveChild
+	case "removechildren":
+		return OpTypeRemoveChildren
+	case "get", "readone", "read_one":
+		return OpTypeGet
+	case "list", "readmany", "read_many":
+		return OpTypeList
+	case "getattributes", "get_attributes":
+		return OpTypeGetAttributes
+	case "setattributes", "set_attributes":
+		return OpTypeSetAttributes
+	}
+
+	return OpTypeUnknown
+}

--- a/pkg/discover/aws/resource.go
+++ b/pkg/discover/aws/resource.go
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package aws
+
+import (
+	"context"
+
+	"github.com/anydotcloud/grm/pkg/names"
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+
+	"github.com/anydotcloud/grm-generate/pkg/config"
+	"github.com/anydotcloud/grm-generate/pkg/model"
+)
+
+// getResourceDefinitionsForService returns a slice of `ResourceDefinition`
+// structs that describe the top-level resources discovered for a supplied AWS
+// service API
+func getResourceDefinitionsForService(
+	ctx context.Context,
+	service string, // the service package name
+	api *awssdkmodel.API,
+	cfg *config.Config,
+) ([]*model.ResourceDefinition, error) {
+	res := []*model.ResourceDefinition{}
+
+	resOpMap := getResourceOperationMap(ctx, api, cfg)
+
+	for resName, ops := range resOpMap {
+		// For now, only care about resources with CREATE operations...
+		if _, found := ops[OpTypeCreate]; !found {
+			continue
+		}
+		resNames := names.New(resName)
+		kind := model.NewKind("aws", service, resNames.Camel)
+		rc := cfg.GetResourceConfig(resName)
+		r := model.NewResourceDefinition(rc, kind)
+		res = append(res, r)
+	}
+	return res, nil
+}

--- a/pkg/discover/resource.go
+++ b/pkg/discover/resource.go
@@ -19,5 +19,5 @@ import (
 
 // DiscoversResources provides a standard interface for resource discovery
 type DiscoversResources interface {
-	DiscoverResources(context.Context) ([]model.ResourceDefinition, error)
+	DiscoverResources(context.Context) ([]*model.ResourceDefinition, error)
 }

--- a/pkg/model/kind.go
+++ b/pkg/model/kind.go
@@ -11,6 +11,10 @@
 
 package model
 
+import (
+	"github.com/gertd/go-pluralize"
+)
+
 // Kind describes a provider-specific, service-specific type of Resource
 type Kind struct {
 	// CloudProvider contains the short name of the cloud provider exposing
@@ -38,8 +42,9 @@ func NewKind(
 	cloudProvider string,
 	service string,
 	name string,
-	pluralName string,
 ) Kind {
+	pluralize := pluralize.NewClient()
+	pluralName := pluralize.Plural(name)
 	return Kind{
 		CloudProvider: cloudProvider,
 		Service:       service,

--- a/pkg/model/resource_definition.go
+++ b/pkg/model/resource_definition.go
@@ -12,14 +12,14 @@
 package model
 
 import (
-	genconfig "github.com/anydotcloud/grm-generate/pkg/config"
+	"github.com/anydotcloud/grm-generate/pkg/config"
 )
 
 // ResourceDefinition describes a single top-level resource in a cloud service
 // API
 type ResourceDefinition struct {
 	// Config contains the resource-specific configuration options
-	Config *genconfig.ResourceConfig
+	Config *config.ResourceConfig
 	// Kind is the type of Resource
 	Kind Kind
 	// Fields is a map, keyed by the **field path**, of Field objects
@@ -30,7 +30,7 @@ type ResourceDefinition struct {
 // NewResourceDefinition returns a pointer to a new ResourceDefinition that
 // describes a single top-level resource in a cloud service API
 func NewResourceDefinition(
-	cfg *genconfig.ResourceConfig,
+	cfg *config.ResourceConfig,
 	kind Kind,
 ) *ResourceDefinition {
 	return &ResourceDefinition{


### PR DESCRIPTION
Adds discovery of resource definitions for AWS service APIs. For now, only the resource definition Kind is determined by inspecting the collection of Operations from the aws-sdk-go private/model.API struct and comparing resource names to a supplied configuration file.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>