### PR TITLE
aws: add in type discovery for Fields

### DIFF
--- a/cmd/grm-generate/command/aws.go
+++ b/cmd/grm-generate/command/aws.go
@@ -62,7 +62,7 @@ func discoverAWS(
 	resources, err := disco.DiscoverResources(ctx)
 	for _, r := range resources {
 		log.Debug("found resource", "resource", r.Kind.Name)
-		for _, path := range r.FieldPaths() {
+		for _, path := range r.GetFieldPaths() {
 			t := r.Fields[path].Definition.Type
 			log.Debug("found field", "resource", r.Kind.Name, "path", path, "type", t.String())
 		}

--- a/pkg/discover/aws/field.go
+++ b/pkg/discover/aws/field.go
@@ -1,0 +1,189 @@
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/anydotcloud/grm/pkg/names"
+	"github.com/anydotcloud/grm/pkg/path/fieldpath"
+	"github.com/anydotcloud/grm/pkg/types/resource/schema"
+	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+
+	"github.com/anydotcloud/grm-generate/pkg/config"
+	"github.com/anydotcloud/grm-generate/pkg/model"
+)
+
+// getFieldDefinition collects information on the field's definition by
+// examining both the FieldConfig and the AWS SDK model ShapeRef.
+func getFieldDefinition(
+	ctx context.Context,
+	path *fieldpath.Path,
+	cfg *config.ResourceConfig,
+	shapeRef *awssdkmodel.ShapeRef,
+) *model.FieldDefinition {
+	def := &model.FieldDefinition{
+		Type:        schema.FieldTypeUnknown,
+		ValueType:   schema.FieldTypeNil,
+		KeyType:     schema.FieldTypeNil,
+		ElementType: schema.FieldTypeNil,
+	}
+	// First try to determine any type information from the field config
+	fc := cfg.GetFieldConfig(path)
+	if fc != nil {
+		if fc.IsReadOnly != nil {
+			def.IsReadOnly = *fc.IsReadOnly
+		}
+		if fc.IsRequired != nil {
+			def.IsRequired = *fc.IsRequired
+		}
+		if fc.IsImmutable != nil {
+			def.IsImmutable = *fc.IsImmutable
+		}
+		if fc.IsSecret != nil {
+			def.IsSecret = *fc.IsSecret
+		}
+		if fc.Type != nil {
+			def.Type = schema.StringToFieldType(*fc.Type)
+		}
+		if fc.ElementType != nil {
+			def.ElementType = schema.StringToFieldType(*fc.ElementType)
+		}
+		if fc.KeyType != nil {
+			def.KeyType = schema.StringToFieldType(*fc.KeyType)
+		}
+		if fc.ValueType != nil {
+			def.ValueType = schema.StringToFieldType(*fc.ValueType)
+		}
+	}
+
+	if def.Type == schema.FieldTypeUnknown {
+		if shapeRef == nil {
+			msg := fmt.Sprintf(
+				"cannot determine field definition/type for %s. "+
+					"No field config or shapeRef supplied.",
+				path,
+			)
+			panic(msg)
+		}
+		// Let's examine the supplied ShapeRef for type information...
+		var shape *awssdkmodel.Shape
+		if shapeRef != nil {
+			shape = shapeRef.Shape
+		}
+		if shape == nil {
+			msg := fmt.Sprintf(
+				"expected non-nil Shape for %s shapeRef",
+				shapeRef.ShapeName,
+			)
+			panic(msg)
+		}
+		def.Type = fieldTypeFromShape(shape)
+		// this is a pointer to the "parent" containing Shape when the field being
+		// processed here is a structure or a list/map of structures.
+		// var containerShape *awssdkmodel.Shape = shape
+		switch shape.Type {
+		case "list", "map":
+			if shape.Type == "list" {
+				def.ElementType = fieldTypeFromShape(shape.MemberRef.Shape)
+			} else {
+				// Currently only map of string keys is supported...
+				def.KeyType = schema.FieldTypeString
+				def.ValueType = fieldTypeFromShape(shape.ValueRef.Shape)
+			}
+			// this is a pointer to the "parent" containing Shape when the field being
+			// processed here is a structure or a list/map of structures.
+			var containerShape *awssdkmodel.Shape = shape
+
+			for {
+				// If the field is a slice or map of structs, we want to add
+				// MemberFields that describe the list or value struct elements so
+				// that a field path can be used to "find" nested struct member
+				// fields.
+				//
+				// For example, the EC2 resource DHCPOptions has a Field called
+				// DHCPConfigurations which is of type []*NewDHCPConfiguration
+				// where the NewDHCPConfiguration struct contains two fields, Key
+				// and Values. If we want to be able to refer to the
+				// DHCPOptions.DHCPConfigurations.Values field by field path, we
+				// need a Field.MemberField that describes the
+				// NewDHCPConfiguration.Values field.
+				//
+				// Here, we essentially dive down into list or map fields,
+				// searching for whether the list or map fields have structure list
+				// element or value element types and then rely on the code below
+				// to "unpack" those struct member fields.
+				if containerShape.Type == "list" {
+					containerShape = containerShape.MemberRef.Shape
+					continue
+				} else if containerShape.Type == "map" {
+					containerShape = containerShape.ValueRef.Shape
+					continue
+				}
+				break
+			}
+
+			if containerShape.Type == "structure" {
+				def.MemberFieldDefinitions = getMemberFieldDefinitions(ctx, cfg, containerShape, path)
+			}
+		case "structure":
+			def.MemberFieldDefinitions = getMemberFieldDefinitions(ctx, cfg, shape, path)
+		}
+	}
+	return def
+}
+
+// fieldTypeFromShape returns the schema.FieldType from an aws-sdk-go
+// Shape.Type string.
+func fieldTypeFromShape(
+	s *awssdkmodel.Shape,
+) schema.FieldType {
+	switch s.Type {
+	case "list":
+		return schema.FieldTypeList
+	case "map":
+		return schema.FieldTypeMap
+	case "structure":
+		return schema.FieldTypeStruct
+	case "timestamp":
+		return schema.FieldTypeTime
+	case "string", "character":
+		return schema.FieldTypeString
+	case "boolean":
+		return schema.FieldTypeBool
+	case "byte", "short", "integer", "long":
+		return schema.FieldTypeInt
+	default:
+		return schema.FieldTypeUnknown
+	}
+}
+
+// getMemberFieldDefinitions returns a map, keyed by normalized field name, of
+// a struct field's member field definitions
+func getMemberFieldDefinitions(
+	ctx context.Context,
+	cfg *config.ResourceConfig,
+	containerShape *awssdkmodel.Shape, // the "parent" or "containing" shape
+	containerPath *fieldpath.Path, // the field path to containing field
+) map[string]*model.FieldDefinition {
+	defs := map[string]*model.FieldDefinition{}
+	for _, memberName := range containerShape.MemberNames() {
+		cleanMemberNames := names.New(memberName)
+		memberPath := containerPath.Copy()
+		memberPath.PushBack(cleanMemberNames.Camel)
+		memberShape := containerShape.MemberRefs[memberName]
+		memberDef := getFieldDefinition(ctx, memberPath, cfg, memberShape)
+		defs[cleanMemberNames.Camel] = memberDef
+	}
+	return defs
+}

--- a/pkg/discover/aws/resource.go
+++ b/pkg/discover/aws/resource.go
@@ -17,11 +17,9 @@ import (
 
 	"github.com/anydotcloud/grm/pkg/names"
 	"github.com/anydotcloud/grm/pkg/path/fieldpath"
-	"github.com/anydotcloud/grm/pkg/types/resource/schema"
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
 
 	"github.com/anydotcloud/grm-generate/pkg/config"
-	"github.com/anydotcloud/grm-generate/pkg/log"
 	"github.com/anydotcloud/grm-generate/pkg/model"
 )
 
@@ -51,6 +49,14 @@ func getResourceDefinitionsForService(
 			return nil, err
 		}
 		r := model.NewResourceDefinition(rc, kind, fields)
+		// Finally, we "flatten" the nested field definitions into a
+		// single-dimension map of Fields in the ResourceDefinition
+		for pathString, f := range r.Fields {
+			path := fieldpath.FromString(pathString)
+			if path.Size() == 1 {
+				flattenField(ctx, rc, r, f, path)
+			}
+		}
 		res = append(res, r)
 	}
 	return res, nil
@@ -75,7 +81,7 @@ func getFieldsForResource(
 		path := fieldpath.FromString(pathString)
 		fieldName := path.Back()
 		fieldNames := names.New(fieldName)
-		fd := getFieldDefinition(ctx, path, fc, nil)
+		fd := getFieldDefinition(ctx, path, cfg, nil)
 		f := model.NewField(fieldNames, path, fc, fd)
 		res[pathString] = f
 	}
@@ -118,82 +124,26 @@ func getFieldsForResource(
 	return res, nil
 }
 
-// getFieldDefinition collects information on the field's definition by
-// examining both the FieldConfig and the AWS SDK model ShapeRef.
-func getFieldDefinition(
+// flattenField recurses through the supplied field definition's member fields
+// ensuring that the resource definition's Fields map contains all nested
+// struct fields, keyed by field path.
+func flattenField(
 	ctx context.Context,
+	cfg *config.ResourceConfig,
+	r *model.ResourceDefinition,
+	f *model.Field,
 	path *fieldpath.Path,
-	cfg *config.FieldConfig,
-	shapeRef *awssdkmodel.ShapeRef,
-) *model.FieldDefinition {
-	l := log.FromContext(ctx)
-	def := &model.FieldDefinition{
-		Type:        schema.FieldTypeUnknown,
-		ValueType:   schema.FieldTypeNil,
-		KeyType:     schema.FieldTypeNil,
-		ElementType: schema.FieldTypeNil,
+) {
+	for memberName, memberDef := range f.Definition.MemberFieldDefinitions {
+		memberPath := path.Copy()
+		memberPath.PushBack(memberName)
+		memberField := r.GetField(memberPath)
+		if memberField == nil {
+			fieldNames := names.New(memberName)
+			fc := cfg.GetFieldConfig(memberPath)
+			memberField = model.NewField(fieldNames, memberPath, fc, memberDef)
+			r.Fields[memberPath.String()] = memberField
+		}
+		flattenField(ctx, cfg, r, memberField, memberPath)
 	}
-	// First try to determine any type information from the field config
-	if cfg != nil {
-		if cfg.IsReadOnly != nil {
-			def.IsReadOnly = *cfg.IsReadOnly
-		}
-		if cfg.IsRequired != nil {
-			def.IsRequired = *cfg.IsRequired
-		}
-		if cfg.IsImmutable != nil {
-			def.IsImmutable = *cfg.IsImmutable
-		}
-		if cfg.IsSecret != nil {
-			def.IsSecret = *cfg.IsSecret
-		}
-		if cfg.Type != nil {
-			def.Type = schema.StringToFieldType(*cfg.Type)
-		}
-		if cfg.ElementType != nil {
-			def.ElementType = schema.StringToFieldType(*cfg.ElementType)
-		}
-		if cfg.KeyType != nil {
-			def.KeyType = schema.StringToFieldType(*cfg.KeyType)
-		}
-		if cfg.ValueType != nil {
-			def.ValueType = schema.StringToFieldType(*cfg.ValueType)
-		}
-	}
-
-	if def.Type == schema.FieldTypeUnknown {
-		if shapeRef == nil {
-			msg := fmt.Sprintf(
-				"cannot determine field definition/type for %s. "+
-					"No field config or shapeRef supplied.",
-				path,
-			)
-			panic(msg)
-		}
-		// Let's examine the supplied ShapeRef for type information...
-		var shape *awssdkmodel.Shape
-		if shapeRef != nil {
-			shape = shapeRef.Shape
-		}
-		// this is a pointer to the "parent" containing Shape when the field being
-		// processed here is a structure or a list/map of structures.
-		// var containerShape *awssdkmodel.Shape = shape
-		switch shape.Type {
-		case "structure":
-			l.Debug("skipping struct field", "path", path.String())
-		case "list":
-			l.Debug("skipping list field", "path", path.String())
-		case "map":
-			l.Debug("skipping map field", "path", path.String())
-		case "timestamp":
-			def.Type = schema.FieldTypeTime
-		case "string", "character":
-			def.Type = schema.FieldTypeString
-		case "boolean":
-			def.Type = schema.FieldTypeBool
-		case "byte", "short", "integer", "long":
-			def.Type = schema.FieldTypeInt
-		}
-	}
-	return def
 }

--- a/pkg/model/field_definition.go
+++ b/pkg/model/field_definition.go
@@ -42,7 +42,7 @@ type FieldDefinition struct {
 	// MemberFieldDefinitions is a map, keyed by member field name, of nested
 	// FieldDefinitions when this Field has a Type of FieldTypeStruct. Returns
 	// nil when Type is not FieldTypeStruct.
-	MemberFieldDefinitions map[string]FieldDefinition
+	MemberFieldDefinitions map[string]*FieldDefinition
 	// IsRequired is true if the field is required to be set by the user
 	IsRequired bool
 	// IsReadOnly is true if the field is not settable by the user

--- a/pkg/model/resource_definition.go
+++ b/pkg/model/resource_definition.go
@@ -13,10 +13,12 @@ package model
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/samber/lo"
 
 	"github.com/anydotcloud/grm-generate/pkg/config"
+	"github.com/anydotcloud/grm/pkg/path/fieldpath"
 )
 
 // ResourceDefinition describes a single top-level resource in a cloud service
@@ -32,10 +34,21 @@ type ResourceDefinition struct {
 }
 
 // FieldPaths returns a sorted list of field paths for this resource.
-func (d *ResourceDefinition) FieldPaths() []string {
+func (d *ResourceDefinition) GetFieldPaths() []string {
 	paths := lo.Keys(d.Fields)
 	sort.Strings(paths)
 	return paths
+}
+
+// GetField returns a Field given a field path. The search is case-insensitive
+func (d *ResourceDefinition) GetField(path *fieldpath.Path) *Field {
+	paths := d.GetFieldPaths()
+	for _, p := range paths {
+		if strings.EqualFold(path.String(), p) {
+			return d.Fields[p]
+		}
+	}
+	return nil
 }
 
 // NewResourceDefinition returns a pointer to a new ResourceDefinition that


### PR DESCRIPTION
Recurses through the AWS API model Shapes along with any ResourceConfig/FieldConfig for a field (identified by field path) and determines the schema.FieldType (and ElementType/ValueType) for the field, adding MemberFieldDefinitions for FieldTypeStruct and lists/maps of structs.

Finally, runs a "flattening" routine at the end of resource definition discovery that ensures all Fields, including nested ones, have a single entry (by field path) in the ResourceDefinition.Fields map.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>