### PR TITLE
add unit tests for pkg/config/resource.go

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	emptyConfig  = config.New()
-	bucketConfig = config.New(
+	emptyConfig = config.New()
+	s3Config    = config.New(
 		config.WithYAML(`
 resources:
   Bucket:
@@ -52,8 +52,8 @@ func TestGetResourceConfigs(t *testing.T) {
 			map[string]*config.ResourceConfig{},
 		},
 		{
-			"Bucket config returns map with single key",
-			bucketConfig,
+			"s3Config returns map with single key",
+			s3Config,
 			map[string]*config.ResourceConfig{
 				"Bucket": &config.ResourceConfig{
 					Fields: map[string]*config.FieldConfig{
@@ -69,5 +69,59 @@ func TestGetResourceConfigs(t *testing.T) {
 	}
 	for _, test := range tests {
 		assert.Equal(test.exp, test.cfg.GetResourceConfigs())
+	}
+}
+
+func TestGetResourceConfig(t *testing.T) {
+	assert := assert.New(t)
+	tests := []struct {
+		name    string
+		resName string
+		cfg     *config.Config
+		exp     *config.ResourceConfig
+	}{
+		{
+			"Nil config returns nil",
+			"Bucket",
+			nil,
+			nil,
+		},
+		{
+			"Empty config returns nil",
+			"Bucket",
+			emptyConfig,
+			nil,
+		},
+		{
+			"Bucket config returns ResourceConfig",
+			"Bucket",
+			s3Config,
+			&config.ResourceConfig{
+				Fields: map[string]*config.FieldConfig{
+					"Name": &config.FieldConfig{
+						Renames: []string{
+							"Bucket",
+						},
+					},
+				},
+			},
+		},
+		{
+			"lowercase Bucket returns ResourceConfig",
+			"bucket",
+			s3Config,
+			&config.ResourceConfig{
+				Fields: map[string]*config.FieldConfig{
+					"Name": &config.FieldConfig{
+						Renames: []string{
+							"Bucket",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		assert.Equal(test.exp, test.cfg.GetResourceConfig(test.resName))
 	}
 }

--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -28,7 +28,7 @@ type ResourceConfig struct {
 
 // GetFieldConfigs returns a map, keyed by field path, of field configurations
 func (c *ResourceConfig) GetFieldConfigs() map[string]*FieldConfig {
-	if c == nil {
+	if c == nil || len(c.Fields) == 0 {
 		return map[string]*FieldConfig{}
 	}
 	return c.Fields

--- a/pkg/config/resource_test.go
+++ b/pkg/config/resource_test.go
@@ -1,0 +1,127 @@
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/anydotcloud/grm/pkg/path/fieldpath"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anydotcloud/grm-generate/pkg/config"
+)
+
+var (
+	emptyResourceConfig = &config.ResourceConfig{}
+	bucketConfig        = s3Config.GetResourceConfig("Bucket")
+)
+
+func TestGetFieldConfigs(t *testing.T) {
+	assert := assert.New(t)
+	tests := []struct {
+		name string
+		cfg  *config.ResourceConfig
+		exp  map[string]*config.FieldConfig
+	}{
+		{
+			"Nil config returns empty map",
+			nil,
+			map[string]*config.FieldConfig{},
+		},
+		{
+			"Empty config returns empty map",
+			emptyResourceConfig,
+			map[string]*config.FieldConfig{},
+		},
+		{
+			"Bucket config returns map with single key",
+			bucketConfig,
+			map[string]*config.FieldConfig{
+				"Name": &config.FieldConfig{
+					Renames: []string{
+						"Bucket",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		assert.Equal(test.exp, test.cfg.GetFieldConfigs())
+	}
+}
+
+func TestGetFieldConfig(t *testing.T) {
+	assert := assert.New(t)
+	tests := []struct {
+		name      string
+		fieldPath string
+		cfg       *config.ResourceConfig
+		exp       *config.FieldConfig
+	}{
+		{
+			"Nil config returns nil",
+			"Name",
+			nil,
+			nil,
+		},
+		{
+			"Empty config returns nil",
+			"Name",
+			emptyResourceConfig,
+			nil,
+		},
+		{
+			"Name returns FieldConfig",
+			"Name",
+			bucketConfig,
+			&config.FieldConfig{
+				Renames: []string{
+					"Bucket",
+				},
+			},
+		},
+		{
+			"lowercase Name returns FieldConfig",
+			"name",
+			bucketConfig,
+			&config.FieldConfig{
+				Renames: []string{
+					"Bucket",
+				},
+			},
+		},
+		{
+			"renamed from Bucket returns FieldConfig",
+			"Bucket",
+			bucketConfig,
+			&config.FieldConfig{
+				Renames: []string{
+					"Bucket",
+				},
+			},
+		},
+		{
+			"renamed from Bucket returns FieldConfig when lowercase rename",
+			"bucket",
+			bucketConfig,
+			&config.FieldConfig{
+				Renames: []string{
+					"Bucket",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		path := fieldpath.FromString(test.fieldPath)
+		assert.Equal(test.exp, test.cfg.GetFieldConfig(path))
+	}
+}


### PR DESCRIPTION
Tests for ResourceConfig including testing that GetFieldConfig properly handles renames of fields.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>