### PR TITLE
adds some more discover/aws/field.go unit tests

### DIFF
--- a/pkg/discover/aws/field.go
+++ b/pkg/discover/aws/field.go
@@ -29,6 +29,10 @@ import (
 func getFieldDefinition(
 	ctx context.Context,
 	path *fieldpath.Path,
+	// NOTE(jaypipes): We pass a ResourceConfig here and not a FieldConfig
+	// because in order to handle renaming in the recursion necessary for
+	// getMemberFieldDefinitions, we need to look up field config by
+	// accumulated field path.
 	cfg *config.ResourceConfig,
 	shapeRef *awssdkmodel.ShapeRef,
 ) *model.FieldDefinition {


### PR DESCRIPTION
Covers a few more permutations of calling getFieldDefinition() using configs with nested paths.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>