### PR TITLE
simplify field processing for resource defs

### DIFF
--- a/cmd/grm-generate/command/aws.go
+++ b/cmd/grm-generate/command/aws.go
@@ -63,7 +63,8 @@ func discoverAWS(
 	for _, r := range resources {
 		log.Debug("found resource", "resource", r.Kind.Name)
 		for _, path := range r.GetFieldPaths() {
-			t := r.Fields[path].Definition.Type
+			f := r.GetField(path)
+			t := f.Definition.Type
 			log.Debug("found field", "resource", r.Kind.Name, "path", path, "type", t.String())
 		}
 	}

--- a/pkg/config/resource_test.go
+++ b/pkg/config/resource_test.go
@@ -66,18 +66,21 @@ func TestGetFieldConfig(t *testing.T) {
 		fieldPath string
 		cfg       *config.ResourceConfig
 		exp       *config.FieldConfig
+		expRepath string
 	}{
 		{
 			"Nil config returns nil",
 			"Name",
 			nil,
 			nil,
+			"",
 		},
 		{
 			"Empty config returns nil",
 			"Name",
 			emptyResourceConfig,
 			nil,
+			"",
 		},
 		{
 			"Name returns FieldConfig",
@@ -88,6 +91,7 @@ func TestGetFieldConfig(t *testing.T) {
 					"Bucket",
 				},
 			},
+			"",
 		},
 		{
 			"lowercase Name returns FieldConfig",
@@ -98,6 +102,7 @@ func TestGetFieldConfig(t *testing.T) {
 					"Bucket",
 				},
 			},
+			"",
 		},
 		{
 			"renamed from Bucket returns FieldConfig",
@@ -108,6 +113,7 @@ func TestGetFieldConfig(t *testing.T) {
 					"Bucket",
 				},
 			},
+			"Name",
 		},
 		{
 			"renamed from Bucket returns FieldConfig when lowercase rename",
@@ -118,10 +124,16 @@ func TestGetFieldConfig(t *testing.T) {
 					"Bucket",
 				},
 			},
+			"Name",
 		},
 	}
 	for _, test := range tests {
 		path := fieldpath.FromString(test.fieldPath)
-		assert.Equal(test.exp, test.cfg.GetFieldConfig(path))
+		fc, repath := test.cfg.GetFieldConfig(path)
+		assert.Equal(test.exp, fc)
+		if test.expRepath != "" {
+			assert.NotNil(repath)
+			assert.Equal(test.expRepath, repath.String())
+		}
 	}
 }

--- a/pkg/discover/aws/field_test.go
+++ b/pkg/discover/aws/field_test.go
@@ -61,8 +61,9 @@ resources:
 	)
 )
 
-func Test_GetFieldDefinition(t *testing.T) {
+func Test_VisitMemberShape(t *testing.T) {
 	assert := assert.New(t)
+	kind := model.NewKind("aws", "s3", "Bucket")
 	tests := []struct {
 		name     string
 		path     string
@@ -124,15 +125,16 @@ func Test_GetFieldDefinition(t *testing.T) {
 	}
 	ctx := context.TODO()
 	for _, test := range tests {
+		rd := model.NewResourceDefinition(test.cfg, kind)
 		path := fieldpath.FromString(test.path)
 		if test.expPanic {
 			assert.Panics(
 				func() {
-					aws.GetFieldDefinition(ctx, path, test.cfg, test.shapeRef)
+					aws.VisitMemberShape(ctx, rd, path, test.cfg, test.shapeRef)
 				},
 			)
 		} else {
-			got := aws.GetFieldDefinition(ctx, path, test.cfg, test.shapeRef)
+			got := aws.VisitMemberShape(ctx, rd, path, test.cfg, test.shapeRef)
 			assert.Equal(test.exp, got)
 		}
 	}

--- a/pkg/discover/aws/resource.go
+++ b/pkg/discover/aws/resource.go
@@ -44,47 +44,26 @@ func GetResourceDefinitionsForService(
 		resNames := names.New(resName)
 		kind := model.NewKind("aws", service, resNames.Camel)
 		rc := cfg.GetResourceConfig(resName)
-		fields, err := GetFieldsForResource(ctx, rc, resName, ops)
+		rd := model.NewResourceDefinition(rc, kind)
+		err := AddFieldsToResourceDefinition(ctx, rd, rc, ops)
 		if err != nil {
 			return nil, err
 		}
-		r := model.NewResourceDefinition(rc, kind, fields)
-		// Finally, we "flatten" the nested field definitions into a
-		// single-dimension map of Fields in the ResourceDefinition
-		for pathString, f := range r.Fields {
-			path := fieldpath.FromString(pathString)
-			if path.Size() == 1 {
-				flattenField(ctx, rc, r, f, path)
-			}
-		}
-		res = append(res, r)
+		res = append(res, rd)
 	}
 	return res, nil
 }
 
-// GetFieldsForResource returns a map, keyed by field path, of Field objects
-// that describe the supplied resource's fields. Fields are collected by
-// looking at the supplied FieldConfig structs and examining the set of
-// Operations involving the resource.
-func GetFieldsForResource(
+// AddFieldsToResourceDefinition iterates over API Operations and a supplied
+// ResourceConfig and adds Fields to the supplied ResourceDefinition, recursing
+// down through any nested fields.
+func AddFieldsToResourceDefinition(
 	ctx context.Context,
+	rd *model.ResourceDefinition,
 	cfg *config.ResourceConfig,
-	resName string,
 	ops map[OpType]*awssdkmodel.Operation,
-) (map[string]*model.Field, error) {
-	res := map[string]*model.Field{}
-
-	// We first iterate over any FieldConfigs listed in our ResourceConfig. The
-	// FieldConfig structs will tell us whether a field has been renamed from
-	// the original AWS API shape.
-	for pathString, fc := range cfg.GetFieldConfigs() {
-		path := fieldpath.FromString(pathString)
-		fieldName := path.Back()
-		fieldNames := names.New(fieldName)
-		fd := GetFieldDefinition(ctx, path, cfg, nil)
-		f := model.NewField(fieldNames, path, fc, fd)
-		res[pathString] = f
-	}
+) error {
+	rName := rd.Kind.Name
 
 	// We start with the Create operation's input and output shape. Members of
 	// the input shape are user-settable. Members of the output shape that are
@@ -93,8 +72,8 @@ func GetFieldsForResource(
 		inputShape := createOp.InputRef.Shape
 		if inputShape == nil {
 			msg := fmt.Sprintf(
-				"expected non-nil Input shape for createOp %s.",
-				createOp.Name,
+				"processing resource %s found nil Input shape for createOp %s.",
+				rName, createOp.Name,
 			)
 			panic(msg)
 		}
@@ -102,48 +81,14 @@ func GetFieldsForResource(
 		for memberName, memberShapeRef := range inputShape.MemberRefs {
 			if memberShapeRef.Shape == nil {
 				msg := fmt.Sprintf(
-					"expected non-nil Shape for member %s in inputShape %s.",
-					inputShape.ShapeName, memberName,
+					"processing resource %s found nil Shape for member %s in inputShape %s.",
+					rName, inputShape.ShapeName, memberName,
 				)
 				panic(msg)
 			}
 			path := fieldpath.FromString(memberName)
-			// NOTE(jaypipes): ResourceConfig.GetFieldConfig accounts for
-			// renamed fields...
-			fc := cfg.GetFieldConfig(path)
-			if fc != nil {
-				// The field is already discovered...
-				continue
-			}
-			fieldNames := names.New(memberName)
-			fd := GetFieldDefinition(ctx, path, nil, memberShapeRef)
-			f := model.NewField(fieldNames, path, fc, fd)
-			res[fieldNames.Camel] = f
+			VisitMemberShape(ctx, rd, path, cfg, memberShapeRef)
 		}
 	}
-	return res, nil
-}
-
-// flattenField recurses through the supplied field definition's member fields
-// ensuring that the resource definition's Fields map contains all nested
-// struct fields, keyed by field path.
-func flattenField(
-	ctx context.Context,
-	cfg *config.ResourceConfig,
-	r *model.ResourceDefinition,
-	f *model.Field,
-	path *fieldpath.Path,
-) {
-	for memberName, memberDef := range f.Definition.MemberFieldDefinitions {
-		memberPath := path.Copy()
-		memberPath.PushBack(memberName)
-		memberField := r.GetField(memberPath)
-		if memberField == nil {
-			fieldNames := names.New(memberName)
-			fc := cfg.GetFieldConfig(memberPath)
-			memberField = model.NewField(fieldNames, memberPath, fc, memberDef)
-			r.Fields[memberPath.String()] = memberField
-		}
-		flattenField(ctx, cfg, r, memberField, memberPath)
-	}
+	return nil
 }

--- a/pkg/discover/aws/resource_test.go
+++ b/pkg/discover/aws/resource_test.go
@@ -13,14 +13,18 @@ package aws_test
 
 import (
 	"context"
+	"sort"
+	"strings"
 	"testing"
 
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anydotcloud/grm-generate/pkg/config"
 	"github.com/anydotcloud/grm-generate/pkg/discover/aws"
+	"github.com/anydotcloud/grm-generate/pkg/model"
 )
 
 func Test_GetResourceDefinitionForService_Panics(t *testing.T) {
@@ -56,7 +60,7 @@ func Test_GetResourceDefinitionForService_Panics(t *testing.T) {
 	}
 }
 
-func Test_GetResourceDefinitionForService_ECR(t *testing.T) {
+func Test_GetResourceDefinitionForService_Kind(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := context.TODO()
@@ -68,5 +72,135 @@ func Test_GetResourceDefinitionForService_ECR(t *testing.T) {
 		ctx, service, api, nil,
 	)
 	require.Nil(err)
-	assert.Equal(2, len(rds))
+	numRDs := 2
+	assert.Equal(numRDs, len(rds))
+
+	names := make([]string, numRDs)
+	pluralNames := make([]string, numRDs)
+	cloudProviders := make([]string, numRDs)
+	services := make([]string, numRDs)
+	for x, rd := range rds {
+		names[x] = rd.Kind.Name
+		pluralNames[x] = rd.Kind.PluralName
+		cloudProviders[x] = rd.Kind.CloudProvider
+		services[x] = rd.Kind.Service
+	}
+	sort.Strings(names)
+	expectNames := []string{
+		"PullThroughCacheRule",
+		"Repository",
+	}
+	assert.Equal(expectNames, names)
+
+	sort.Strings(pluralNames)
+	expectPluralNames := []string{
+		"PullThroughCacheRules",
+		"Repositories",
+	}
+	assert.Equal(expectPluralNames, pluralNames)
+
+	assert.Equal([]string{"aws"}, lo.Uniq(cloudProviders))
+
+	assert.Equal([]string{"ecr"}, lo.Uniq(services))
+}
+
+func Test_GetResourceDefinitionForService_FieldPaths_NoConfig(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.TODO()
+	service := "ecr"
+	api := apis[service]
+	require.NotNil(api, "expected non-nil API for ECR service")
+	require.Equal(api.PackageName(), "ecr")
+	rds, err := aws.GetResourceDefinitionsForService(
+		ctx, service, api, nil,
+	)
+	require.Nil(err)
+
+	var repoRD *model.ResourceDefinition
+	for _, rd := range rds {
+		if strings.EqualFold(rd.Kind.Name, "repository") {
+			repoRD = rd
+			break
+		}
+	}
+	require.NotNil(repoRD)
+
+	fieldPaths := []string{}
+	for _, fPath := range repoRD.GetFieldPaths() {
+		fieldPaths = append(fieldPaths, fPath.String())
+	}
+	sort.Strings(fieldPaths)
+
+	expectFieldPaths := []string{
+		"EncryptionConfiguration",
+		"EncryptionConfiguration.EncryptionType",
+		"EncryptionConfiguration.KMSKey",
+		"ImageScanningConfiguration",
+		"ImageScanningConfiguration.ScanOnPush",
+		"ImageTagMutability",
+		"RegistryID",
+		"RepositoryName",
+		"Tags",
+		"Tags.Key",
+		"Tags.Value",
+	}
+	assert.Equal(expectFieldPaths, fieldPaths)
+}
+
+func Test_GetResourceDefinitionForService_FieldPaths_RenamingConfig(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.TODO()
+	service := "ecr"
+	api := apis[service]
+	require.NotNil(api, "expected non-nil API for ECR service")
+	require.Equal(api.PackageName(), "ecr")
+
+	cfg := config.New(
+		config.WithYAML(`
+resources:
+  Repository:
+    fields:
+      Name:
+		renames:
+         - RepositoryName
+`,
+		),
+	)
+
+	rds, err := aws.GetResourceDefinitionsForService(
+		ctx, service, api, cfg,
+	)
+	require.Nil(err)
+
+	var repoRD *model.ResourceDefinition
+	for _, rd := range rds {
+		if strings.EqualFold(rd.Kind.Name, "repository") {
+			repoRD = rd
+			break
+		}
+	}
+	require.NotNil(repoRD)
+
+	fieldPaths := []string{}
+	for _, fPath := range repoRD.GetFieldPaths() {
+		fieldPaths = append(fieldPaths, fPath.String())
+	}
+	sort.Strings(fieldPaths)
+
+	expectFieldPaths := []string{
+		"EncryptionConfiguration",
+		"EncryptionConfiguration.EncryptionType",
+		"EncryptionConfiguration.KMSKey",
+		"ImageScanningConfiguration",
+		"ImageScanningConfiguration.ScanOnPush",
+		"ImageTagMutability",
+		"Name",
+		"RegistryID",
+		"Tags",
+		"Tags.Key",
+		"Tags.Value",
+	}
+	assert.Equal(expectFieldPaths, fieldPaths)
 }


### PR DESCRIPTION
Simplifies and cleans up the field processing for ResourceDefinitions in the `pkg/discover/aws` package in a few ways:

* More cleanly handle field renames by returning any renamed field path from `pkg/config.ResourceConfig:GetFieldConfig()`
* Remove `pkg/model.Field.Names` field and replace with a `Names()` method that simply returns the normalized back of the Field's Path
* Normalize the fieldpath supplied in `pkg/model.NewField`
* A new `pkg/model.ResourceDefinition:AddField()` method
* Use the Visitor pattern to recurse into the nested field structures instead of trying to recurse into the field structures and return FieldDefinitions.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>